### PR TITLE
Window Active with .exe name + Shift a,s,d,w support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div style="text-align:center">
+<div>
     <img width="33%" src="./logo.png" />
 </div>
 
@@ -21,7 +21,12 @@ Les touches fléchées fonctionnent régulièrement dans les autres applications
 1. Installer [AutoHotkey](https://www.autohotkey.com/)
 2. Lancer le script
 3. Focuser l'application Dofus - **Le jeu doit être centré dans l'écran**
-4. Appuyer sur une flèche du clavier
+4. Appuyer sur une flèche du clavier ou une combinaison de touches supportée!
+
+## Touches qui peuvent être utilisées pour bouger:
+
+- Touches fléchées
+- Combinaison de Shift+A,S,D,W
 
 ---
 
@@ -39,4 +44,9 @@ Arrow keys will work as usual in other application**
 1. Install [AutoHotkey](https://www.autohotkey.com/)
 2. Launch the script
 3. Focus Dofus - **The game must be centered in the screen**
-4. Press an arrow key!
+4. Press an arrow key or a supported key combination!
+
+## Touches qui peuvent être utilisées pour bouger:
+
+- Arrow keys
+- Combination of Shift+A,S,D,W

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Les touches fléchées fonctionnent régulièrement dans les autres applications
 ## Touches qui peuvent être utilisées pour bouger:
 
 - Touches fléchées
-- Combinaison de Shift+A,S,D,W
+- Combinaison de Shift+A,S,D,W (Si vous les activez en décommentant le code)
 
 ---
 
@@ -49,4 +49,4 @@ Arrow keys will work as usual in other application**
 ## Touches qui peuvent être utilisées pour bouger:
 
 - Arrow keys
-- Combination of Shift+A,S,D,W
+- Combination of Shift+A,S,D,W (Enabled by uncommenting the code)

--- a/movement_script.ahk
+++ b/movement_script.ahk
@@ -48,7 +48,7 @@ SlowMouseMove(DistanceX, DistanceY)
 
 ; Orchestrate everything to change map
 ChangeMap(x, y) {
-    If WinActive("Dofus") {
+    If WinActive("ahk_exe Dofus.exe") {
         initialPositionCoords := GetMousePosition()
         CenterMouse()
         Click("down")
@@ -61,22 +61,25 @@ ChangeMap(x, y) {
     }
 }
 
++a::
 Left::
     {
         ChangeMap(200, 0)
 
     }
-
++d::
 Right::
     {
         ChangeMap(-200, 0)
     }
 
++w::
 Up::
     {
         ChangeMap(0, 200)
     }
 
++s::
 Down::
     {
         ChangeMap(0, -200)

--- a/movement_script.ahk
+++ b/movement_script.ahk
@@ -61,25 +61,25 @@ ChangeMap(x, y) {
     }
 }
 
-+a::
+; +a::
 Left::
     {
         ChangeMap(200, 0)
 
     }
-+d::
+; +d::
 Right::
     {
         ChangeMap(-200, 0)
     }
 
-+w::
+; +w::
 Up::
     {
         ChangeMap(0, 200)
     }
 
-+s::
+; +s::
 Down::
     {
         ChangeMap(0, -200)


### PR DESCRIPTION
 Changes:
 
 - Uses the name of the executable to see if the window is active
 - Added support for Shift+a,s,d,w (Disabled by default)